### PR TITLE
Add line explaining how to access superuser on self-hosted

### DIFF
--- a/apps/docs/content/guides/database/postgres/roles-superuser.mdx
+++ b/apps/docs/content/guides/database/postgres/roles-superuser.mdx
@@ -16,3 +16,7 @@ However, this does mean that some operations, that typically require `superuser`
 - `CREATE EVENT TRIGGER`
 - `COPY ... FROM PROGRAM`
 - `ALTER USER ... WITH SUPERUSER`
+
+## Self-hosted instances
+
+The `supabase_admin` role has `superuser` privileges. While it's not possible to access this role on hosted Supabase projects, you _can_ access it on self-hosted instances using the same password as the `postgres` role, which is `postgres` by default.


### PR DESCRIPTION
It's still possible to access `superuser` privileges on self-hosted instances, but the docs don't explain how. This short section remedies that.

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs update

## Additional context

It is still necessary in some situations to have superuser access to a self-hosted instance. One I ran into recently was [running unit tests with `#[sqlx::test]`](https://github.com/launchbadge/sqlx/discussions/2051#discussioncomment-3401865) using the Rust sqlx library. The docs should make it clear how to do this.